### PR TITLE
Format countdown in hours and minutes

### DIFF
--- a/format.js
+++ b/format.js
@@ -1,0 +1,11 @@
+function formatMinutes(mins){
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  const parts = [];
+  if(h) parts.push(h + " h");
+  if(m) parts.push(m + " min");
+  if(!h && !m) parts.push("0 min");
+  return parts.join(" ");
+}
+
+module.exports = { formatMinutes };

--- a/index.html
+++ b/index.html
@@ -69,6 +69,16 @@ function parseToday(timeHHMM){
 }
 function minutesDiff(a,b){ return Math.round((b - a)/60000); }
 
+function formatMinutes(mins){
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  const parts = [];
+  if(h) parts.push(h + " h");
+  if(m) parts.push(m + " min");
+  if(!h && !m) parts.push("0 min");
+  return parts.join(" ");
+}
+
 function nextTrip(schedule){
   const now = new Date();
   for(const t of schedule){
@@ -116,7 +126,7 @@ function refresh(){
     card.innerHTML = `
       <h2>${title}</h2>
       <div class="time">${time}</div>
-      <div class="badge">${mins===0 ? "Now" : mins+" min&nbsp;away"}</div>
+      <div class="badge">${mins===0 ? "Now" : formatMinutes(mins)+"&nbsp;away"}</div>
       <details class="schedule">
         <summary>Today's remaining trips</summary>
         <ul>${listItems}</ul>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Next shuttle schedule viewer for Altris Residence",
   "scripts": {
-    "test": "echo \"No tests specified\""
+    "test": "node test/format.test.js"
   },
   "license": "MIT"
 }

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { formatMinutes } = require('../format');
+
+assert.strictEqual(formatMinutes(45), '45 min');
+assert.strictEqual(formatMinutes(60), '1 h');
+assert.strictEqual(formatMinutes(61), '1 h 1 min');
+assert.strictEqual(formatMinutes(125), '2 h 5 min');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- show countdown badge using `formatMinutes()`
- add `formatMinutes` helper for hour+minute formatting
- expose helper via `format.js`
- add unit tests for `formatMinutes`
- wire up `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c002cf50832e8bac017ded19d7e2