### PR TITLE
Enhance shuttle cards with glass look

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,17 +6,18 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   :root {
+    --card-bg: rgba(255, 255, 255, 0.65);
+    --card-blur: blur(16px);
     --brand: #0e3e6a;        /* deep navy */
     --accent: #46c0c7;       /* teal line */
     --bg: #f9fcff;
-    --card: #ffffff;
     font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
   }
-  html,body{margin:0;padding:0;background:var(--bg);color:var(--brand);}
+  html,body{margin:0;padding:0;background:linear-gradient(135deg,var(--bg),#e0edf7);color:var(--brand);}
   .wrapper{max-width:680px;margin:auto;padding:2rem 1rem;}
   h1{font-size:clamp(1.6rem,4.5vw,2.2rem);margin:0 0 .25em}
   h2{font-size:1.25rem;margin:.5em 0 .25em;color:var(--accent);letter-spacing:.5px;font-weight:600}
-  .card{background:var(--card);border-radius:12px;padding:1.25rem 1.5rem;box-shadow:0 4px 12px rgba(0,0,0,.05);margin-bottom:1.25rem}
+  .card{background:var(--card-bg);border-radius:12px;padding:1.25rem 1.5rem;box-shadow:0 8px 24px rgba(0,0,0,0.1);backdrop-filter:var(--card-blur);margin-bottom:1.25rem}
   .time{font-size:2rem;font-weight:600}
   .badge{font-size:.9rem;color:#555}
   details.schedule{margin-top:.75rem;font-size:.9rem}


### PR DESCRIPTION
## Summary
- add translucent card variables and blur to `<style>`
- use new variables to style cards with glass backdrop
- add a light gradient for the page background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68478d451c04832e91cb158b07a59f95